### PR TITLE
Fix mk2 crash when built

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -200,7 +200,6 @@ script.on_event(defines.events.on_built_entity, function(event)
 	local nextUpdate = event.tick + 60
 	table.insert(global.tf.fieldList, entInfo)
 	insertFieldmk2(entInfo, nextUpdate)
-    showFieldmk2GUI(#global.tf.fieldmk2sToMaintain, event.player_index)
     global.tf.playersData[event.player_index].guiOpened = entInfo.entity
     event.created_entity.destroy()
     return

--- a/control.lua
+++ b/control.lua
@@ -646,7 +646,7 @@ function fieldmk2Maintainer(tick)
 		else
 			local seedInInv = {}
 			for _, seedType in pairs(global.tf.seedPrototypes) do
-				local newAmount = fieldObj,entity.get_item_count(seedType.states[1])
+				local newAmount = fieldObj.entity.get_item_count(seedType.states[1])
 				if newAmount > 0 then
 					seedInInv = 
 					{


### PR DESCRIPTION
Hello,

I'm playing with a 30 hours game and when I added Treefarm mod and tried to build my first mk2 farm the game crashed on indexing _global.tf.fieldList[index].active_ in the _showFieldmk2GUI_ function. 
When I removed the showFieldmk2GUI line when building, the game didn't crash, but I ran into a typo.

Since the small fixes the GUI appears when I click on the mk2 farm, so far so good.

Thanks for the mod ;)
Hope this helps a little
