### PR TITLE
Feature/performance

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1,7 +1,7 @@
 require "defines"
 require "interfaces"
 
-local constIsInDebug = true
+local constIsInDebug = false
 local constFertilizerName = "tf-fertilizer"
 local constRobotFarmOverlayName = "tf-fieldmk2Overlay"
 local constRobotFarmName = "tf-fieldmk2"
@@ -817,7 +817,7 @@ function tick_farms(group_num)
 		local farmInfo = global.tf.farms[i]
 		if farmInfo ~= nil then
 			if not farmInfo.entity.valid then
-				debug_print("farm did not have a valid entity")
+				--debug_print("farm did not have a valid entity")
 				table.remove(global.tf.farms, i)
 				i = i - 1
 			elseif farmInfo.isActive then

--- a/control.lua
+++ b/control.lua
@@ -78,9 +78,12 @@ end
 function data_migration_to_v4()
 
 	-- convert field data
-	--global.tf.fieldsToMaintain = nil
-	--global.tf.fieldmk2sToMaintain = nil
+	global.tf.fieldsToMaintain = nil
+	global.tf.fieldmk2sToMaintain = nil
 	global.tf.farms = {}
+	
+	-- set to empty list in case there are no fields planted
+	global.tf.fieldList = global.tf.fieldList or {}
 	for idx, field in ipairs(global.tf.fieldList) do
 		if field.entity.valid then
 			local farmInfo = create_farm_info_for(field.entity)
@@ -98,10 +101,13 @@ function data_migration_to_v4()
 			table.insert(global.tf.farms, farmInfo)
 		end
 	end
-	--global.tf.fieldList = nil
+	global.tf.fieldList = nil
 	
 	-- convert tree data
 	global.tf.trees = {}
+	
+	-- set to empty list in case there are no trees growing
+	global.tf.treesToGrow = global.tf.treesToGrow or {}
 	for tick, list in pairs(global.tf.treesToGrow) do
 		-- for each record, the associated farm will be found when the tree is ready to be harvested
 		global.tf.trees[tick] = list
@@ -115,7 +121,8 @@ function data_migration_to_v4()
 	global.tf.seedPrototypes = nil
 	
 	-- convert player data and clear all open guis
-	global.tf.playerData = global.tf.playersData or {}
+	global.tf.playersData = global.tf.playersData or {}
+	global.tf.playerData = global.tf.playersData
 	for idx, info in ipairs(global.tf.playersData) do
 		clear_player_data(idx)
 		
@@ -503,7 +510,6 @@ function mk2_next_planting_position(farmInfoSelf)
 	
 	return farmInfoSelf.private_current_planting_pos
 end
-
 
 function mk1_harvest_tree(farmInfoSelf, treeEntity)
 

--- a/control.lua
+++ b/control.lua
@@ -654,7 +654,8 @@ end
 function event_handle_configuration_gui_click(event)
 
 	local playerInfo = global.tf.playerData[event.player_index]
-	if playerInfo.farmInfoConfiguring == nil then
+	if playerInfo == nil or playerInfo.farmInfoConfiguring == nil then
+		-- player will sometimes be nil if the gui does not belong to any player e.g. the TestMode mod
 		-- not configuring anything so there is nothing to do
 		return
 	end

--- a/control.lua
+++ b/control.lua
@@ -163,6 +163,8 @@ end
 
 function dump_element(key, value, indent)
 
+	indent = indent or ".    "
+
 	if value == nil then
 		debug_print(indent .. key .. " = nil")
 	elseif type(value) == "table" then
@@ -210,6 +212,14 @@ end
 --
 -- managing players
 --
+
+function get_player_info(player_index)
+	if global.tf.playerData[player_index] == nil then
+		clear_player_data(player_index)
+	end
+	
+	return global.tf.playerData[player_index]
+end
 
 function clear_player_data(player_index)
 	global.tf.playerData[player_index] = { farmInfoConfiguring = nil, overlayEntities = {} }
@@ -653,9 +663,8 @@ end
 
 function event_handle_configuration_gui_click(event)
 
-	local playerInfo = global.tf.playerData[event.player_index]
-	if playerInfo == nil or playerInfo.farmInfoConfiguring == nil then
-		-- player will sometimes be nil if the gui does not belong to any player e.g. the TestMode mod
+	local playerInfo = get_player_info(event.player_index)
+	if playerInfo.farmInfoConfiguring == nil then
 		-- not configuring anything so there is nothing to do
 		return
 	end
@@ -719,7 +728,7 @@ end
 
 function construct_farm_configuration_gui(playerIndex, farmInfo)
 	local player = game.players[playerIndex]
-	local playerInfo = global.tf.playerData[playerIndex]
+	local playerInfo = get_player_info(playerIndex)
 	
 	playerInfo.farmInfoConfiguring = farmInfo
 	
@@ -761,7 +770,7 @@ end
 
 function clear_farm_configuration_gui(playerIndex)
 	local player = game.players[playerIndex]
-	local playerInfo = global.tf.playerData[playerIndex]
+	local playerInfo = get_player_info(playerIndex)
 	
 	if player.gui.center.treefarmGui ~= nil then
 		player.gui.center.treefarmGui.destroy()

--- a/control.lua
+++ b/control.lua
@@ -1,6 +1,22 @@
 require "defines"
 require "interfaces"
 
+function test_addFieldMk2(ent)
+	local entInfo =
+    {
+      entity = ent,
+      active = true,
+      areaRadius = 9,
+      fertAmount = 0,
+      lastSeedPos = {x = -9, y = -9},
+      toBeHarvested = {}
+    }
+	local nextUpdate = game.tick + 60
+	table.insert(global.tf.fieldList, entInfo)
+	insertFieldmk2(entInfo, nextUpdate)
+    
+end
+
 function initialise()
 	global.tf = {}
 	global.tf.fieldList = {}

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Treefarm-Lite",
-  "version": "0.3.7",
+  "version": "0.4.0",
   "title": "Treefarm-Lite",
   "author": "drs, Blu3wolf",
   "dependencies": ["base >= 0.12.12"],

--- a/interfaces.lua
+++ b/interfaces.lua
@@ -2,95 +2,36 @@ module(..., package.seeall)
 
 remote.add_interface("treefarm_interface",
 {
-  addSeed = function(seedInfo)
-    if global.tf == nil then
-      return "treefarm isn't initialized yet. Save the game and reload it."
-    end
+	addSeed = function(seedInfo)
+		
+		if seedInfo.name == nil then return "name not defined" end
+		if seedInfo.states == nil then return "growing states not defined" end
+		if seedInfo.efficiency == nil then return "efficiency not defined" end
+		if seedInfo.basicGrowingTime == nil or seedInfo.basicGrowingTime <= 0 then return "basicGrowingTime not defined" end
+		if seedInfo.randomGrowingTime == nil or seedInfo.randomGrowingTime <= 0 then return "randomGrowingTime not defined" end
+		if seedInfo.fertilizerBoost == nil or seedInfo.fertilizerBoost <= 0 then return "fertilizerBoost not defined" end
+		
+		local newPlantGroupList = {}
+		newPlantGroupList[seedInfo.name] = seedInfo
+		
+		register_plant_groups( newPlantGroupList )
+	end,
 
-    if global.tf.seedPrototypes[seedInfo.name] == nil then
-      global.tf.seedPrototypes[seedInfo.name] = {}
-      if seedInfo.states ~= nil then
-        global.tf.seedPrototypes[seedInfo.name].states = seedInfo.states
-      else
-        return "growing states not defined"
-      end
-      if seedInfo.output ~= nil then
-        global.tf.seedPrototypes[seedInfo.name].output = seedInfo.output
-      else
-        return "result not defined"
-      end
-      if seedInfo.efficiency then
-        global.tf.seedPrototypes[seedInfo.name].efficiency = seedInfo.efficiency
-        if global.tf.seedPrototypes[seedInfo.name].efficiency.other == 0 then
-          global.tf.seedPrototypes[seedInfo.name].efficiency.other = 0.01
-        end
-      else
-        return "efficiency not defined"
-      end
-      if seedInfo.basicGrowingTime ~= nil then
-        global.tf.seedPrototypes[seedInfo.name].basicGrowingTime = seedInfo.basicGrowingTime
-      else
-        return "basicGrowingTime not defined"
-      end
-      if seedInfo.randomGrowingTime ~= nil then     
-        global.tf.seedPrototypes[seedInfo.name].randomGrowingTime = seedInfo.randomGrowingTime
-      else
-        return "randomGrowingTime not defined"
-      end
-      if seedInfo.fertilizerBoost ~= nil then
-        global.tf.seedPrototypes[seedInfo.name].fertilizerBoost = seedInfo.fertilizerBoost
-      else
-        return "fertilizerBoost not defined"
-      end
-      
-      if seedTypeLookUpTable ~= nil then
-        seedTypeLookUpTable = {}
-      end
-      populateSeedTypeLookUpTable()
-    else
-      return "seed type already present"
-    end
-  end,
+	readSeed = function(seedName)
+		return global.tf.plantGroups[seedName]
+	end,
 
-  readSeed = function(seedName)
-    return global.tf.seedPrototypes[seedName]
-  end,
-
-  getSeedTypesData = function()
-    return global.tf.seedPrototypes
-  end,
+	getSeedTypesData = function()
+		return global.tf.plantGroups
+	end,
 
 
-  getNumGrowing = function()
-    return #global.tf.growing
-  end,
-
-  getFirstPlantTick = function()
-    return global.tf.growing[1].nextUpdate
-  end,
-
-  removeAllPlants = function()
-    for _, plant in ipairs(global.tf.growing) do
-      if plant.entity.valid then
-        plant.entity.destroy()
-      end
-    end
-
-    while (#global.tf.growing > 0) do
-      table.remove(global.tf.growing)
-    end
-  end,
-
-  clearGUIs = function()
-    for pIndex, player in ipairs(game.players) do
-      if player.gui.center.fieldmk2Root ~= nil then
-        player.gui.center.fieldmk2Root.destroy()
-      end
-      global.tf.playersData[pIndex].guiOpened = false
-      destroyOverlay(pIndex)
-    end
-  end,
-
+	clearGUIs = function()
+		for pIndex, player in ipairs(game.players) do
+			clear_farm_configuration_gui(pIndex)
+		end
+	end,
+	
   gimmeStuff1 = function(pIndex)
     if pIndex == 0 then
       for i,_ in ipairs(game.players) do
@@ -182,17 +123,27 @@ remote.add_interface("treefarm_interface",
     local seed_type = "tf-germling"
     local x_offset = origin_position.x or origin_position[1]
     local y_offset = origin_position.y or origin_position[2]
-    local stack_size = num_seeds or game.get_item_prototype ( seed_type ).stack_size
+    local seed_quantity = num_seeds or game.get_item_prototype ( seed_type ).stack_size
+	local fertilizer_quantity = 0
+	if game.item_prototypes["tf-fertilizer"] ~= nil then
+		fertilizer_quantity = game.get_item_prototype ( "tf-fertilizer" ).stack_size
+	end
     
     for i = -coordinate + x_offset + 10, coordinate + x_offset - 10, field_size do 
         for j = -coordinate + y_offset + 10, coordinate + y_offset - 10, field_size do 
             
-            local ent = game.player.surface.create_entity({name=treefarm_type, position= {i,j}, force=game.forces.player })
-            if (stack_size > 0) then
-                ent.insert({name=seed_type, count=stack_size})
+            local ent = game.player.surface.create_entity({name=treefarm_type, position= {j,i}, force=game.forces.player })
+            if (seed_quantity > 0) then
+                ent.insert({name=seed_type, count=seed_quantity})
+				
+				if fertilizer_quantity > 0 then
+					ent.insert({name="tf-fertilizer", count=fertilizer_quantity})
+				end
             end
+			
+			
                 
-            test_addFieldMk2(ent)
+            on_farm_created(ent)
             
             num_treefarms = num_treefarms - 1
             if (num_treefarms == 0) then
@@ -202,8 +153,20 @@ remote.add_interface("treefarm_interface",
         end 
     end
     
-  end
+  end,
   
+  test_deconstruct_marked_trees = function(num_treefarms)
+	local field_size = 20
+	local treefarms_per_side = math.ceil(math.sqrt(num_treefarms))
+	local coordinate = treefarms_per_side * field_size / 2
+
+	for k, v in pairs(game.player.surface.find_entities_filtered({type="tree", area={ {-coordinate, -coordinate}, {coordinate,coordinate}} })) do 
+		if v.to_be_deconstructed(game.player.force) then 
+			v.destroy() 
+		end 
+	end
+	
+  end
   
  })
 

--- a/interfaces.lua
+++ b/interfaces.lua
@@ -124,7 +124,87 @@ remote.add_interface("treefarm_interface",
     if game.forces.player.technologies["tf-biological-warfare"] ~= nil then
       game.forces.player.technologies["tf-biological-warfare"].researched = true
     end
+  end,
+  
+  test_setup_world = function(num_treefarms, origin_position, surface)
+    
+    -- if no origin is given then center on the center of the world
+    origin_position = origin_position or { 0,0 }
+    
+    -- default to the player's surface
+    surface = surface or game.player.surface
+    
+    -- we will place treefarms in a box centered around the origin
+    -- so each side of the box is sqrt(num_treefarms) long
+    local treefarms_per_side = math.ceil(math.sqrt(num_treefarms))
+    
+    -- each treefarm occupies a 20x20 tile box, each chunk is 32x32
+    -- and we only need half of the chunks (b/c we want the radius not the diameter)
+    local chunk_radius = (treefarms_per_side * 20 / 32 ) / 2;
+    local coordinate = treefarms_per_side * 20 / 2;
+    local x_offset = origin_position.x or origin_position[1]
+    local y_offset = origin_position.y or origin_position[2]
+    
+    -- generate the necessary chunks
+    surface.request_to_generate_chunks( origin_position, chunk_radius)
+
+    -- remove all the entities from a 1000 unit box around the center
+    for _, v in pairs(surface.find_entities ({{-coordinate + x_offset,-coordinate + y_offset}, {coordinate + x_offset,coordinate + y_offset}})) 
+        do v.destroy() 
+    end
+
+    -- replace all the terrain w/ grass terrain
+
+    for i = -coordinate + x_offset, coordinate + x_offset, 1 do 
+        for j = -coordinate + y_offset,coordinate + y_offset,1 do 
+            surface.set_tiles ({ { name = "grass", position = { i,j } } }) 
+        end 
+    end
+  
+  end,
+  
+  test_create_treefarms = function(num_treefarms, origin_position, num_seeds, treefarm_type, surface)
+
+    -- if no origin is given then center on the center of the world
+    origin_position = origin_position or { 0,0 }
+    
+    -- default to the player's surface
+    surface = surface or game.player.surface
+    
+    -- default to treefarm mk2
+	-- NOTE other farm types are not supported
+    treefarm_type = "tf-fieldmk2" -- treefarm_type or "tf-fieldmk2"
+
+    local field_size = 20
+    local treefarms_per_side = math.ceil(math.sqrt(num_treefarms))
+    local coordinate = treefarms_per_side * field_size / 2
+    
+    local seed_type = "tf-germling"
+    local x_offset = origin_position.x or origin_position[1]
+    local y_offset = origin_position.y or origin_position[2]
+    local stack_size = num_seeds or game.get_item_prototype ( seed_type ).stack_size
+    
+    for i = -coordinate + x_offset + 10, coordinate + x_offset - 10, field_size do 
+        for j = -coordinate + y_offset + 10, coordinate + y_offset - 10, field_size do 
+            
+            local ent = game.player.surface.create_entity({name=treefarm_type, position= {i,j}, force=game.forces.player })
+            if (stack_size > 0) then
+                ent.insert({name=seed_type, count=stack_size})
+            end
+                
+            test_addFieldMk2(ent)
+            
+            num_treefarms = num_treefarms - 1
+            if (num_treefarms == 0) then
+                return
+            end
+            
+        end 
+    end
+    
   end
+  
+  
  })
 
 


### PR DESCRIPTION
rewrote treefarm code based on the work @Rseding91 did
includes all the performance work I posted on the initial issue request as well
so... 2500 mk2 farms are easily supported. support for mk1s is harder to measure but will be comparable

I updated the TreeFarm version to 4.0 and tested upgrading from v3.7 to v4.0 - which works
I also tested w/ latest versions of Treefarm-AC, Treefarm-Caffiene, and Treefarm-AlienPlant, all of which work for both upgraded saves and new games. I have not tested dytec or any other mods that add plants. I also took a look through the bug history and tested this new version for those bugs, fixing the ones I found.

All uses of the Surface and Force are correct - no hardcoded references to "nauvis" or game.forces.player

notes
- game.item_prototypes[] is slow (so its not used)
- lots of outstanding deconstruction requests will severely degrade performance
