### PR TITLE
Fix inneficiency when output is full

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -240,6 +240,9 @@ function initialize()
 	global.tf.counter = global.tf.counter or 0
 	global.tf.playerData = global.tf.playerData or {}
 	
+	-- we want to clear this on load in case changing a mod has changed a stack size
+	global.tf.knownStackSizes = {}
+	
 	if game ~= nil then
 		global.tf.isFertilizerAvailable = game.item_prototypes[constFertilizerName] ~= nil
 	end
@@ -590,7 +593,11 @@ end
 function harvest_trees_within_farm_area(farmInfo)
 	-- If we can't stuff into the output, there isn't any point checking each tree
 	for name,number in pairs(farmInfo.entity.get_output_inventory().get_contents()) do
-		local stack_size = game.item_prototypes[name].stack_size
+		local stack_size = global.tf.knownStackSizes[name]
+		if (nil == stack_size) then
+			stack_size = game.item_prototypes[name].stack_size
+			global.tf.knownStackSizes[name] = stack_size
+		end
 		
 		-- TODO: don't hardcode this
 		if (number > stack_size - 10) then

--- a/control.lua
+++ b/control.lua
@@ -588,7 +588,16 @@ function mk2_unharvest_tree(farmInfoSelf, treeEntity)
 end
 
 function harvest_trees_within_farm_area(farmInfo)
-
+	-- If we can't stuff into the output, there isn't any point checking each tree
+	for name,number in pairs(farmInfo.entity.get_output_inventory().get_contents()) do
+		local stack_size = game.item_prototypes[name].stack_size
+		
+		-- TODO: don't hardcode this
+		if (number > stack_size - 10) then
+			return
+		end
+	end
+	
 	-- harvest any mature trees within the field's boundaries
 	local boundary = farmInfo.get_farm_boundaries(farmInfo)
 	
@@ -877,7 +886,6 @@ function tick_farms(group_num)
 				end
 			end
 			
-			-- TODO horribly inneficient when output is full and isn't being emptied
 			if farmInfo.entity.name == constFarmName then
 				harvest_trees_within_farm_area(farmInfo)
 			end


### PR DESCRIPTION
Check to see if we can actually put stuff into the output inventory
before checking each tree.

There are two potential ways to remove the hard-coded value.  First, we
could look up the max amount that can drop from a tree at runtime and
put it there.  Alternatively, we could allow the output stack to go over
max if it was under max before we tried to add stuff to it.  This is
already done in some places for the vanilla game.
