### PR TITLE
Fixed warning message when the mk1 treefarm is tried to place in an ...

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -363,7 +363,6 @@ end
 -- creating and managing farms
 --
 
-
 function event_built_entity(event)
 
 	if event.created_entity.name == constFarmName then
@@ -374,8 +373,8 @@ function event_built_entity(event)
 		else
 			local drop_item_on_ground = true -- robots will drop the item on the group, b/c they can't do anything else
 			
-			-- we won't have a player if this farm was built via robots by blueprint
-			if event.name == "on_built_entity" then
+			-- we won't have a player if this farm was built via robots by blueprint 
+			if event.name == defines.events.on_built_entity then
 				local player = game.players[event.player_index]
 				
 				-- add the item back to the player's inventory
@@ -389,6 +388,12 @@ function event_built_entity(event)
 			
 			if drop_item_on_ground then
 				event.created_entity.surface.spill_item_stack(event.created_entity.position, { name=constFarmName, count=1 });
+				
+				-- tell everyone on the same force that the building failed
+				for _, plyr in pairs(event.created_entity.force.players) do
+					plyr.print({"robot_buildingFail", event.created_entity.position.x, event.created_entity.position.y })
+				end
+				
 			end
 			
 			event.created_entity.destroy()

--- a/script-locale/de.cfg
+++ b/script-locale/de.cfg
@@ -5,3 +5,4 @@ notActive=nicht aktiv
 toggleButtonCaption=umschalten
 usedArea=bewirtschaftete Fläche:
 okButtonCaption=ok
+robot_buildingFail=Robot could not place a treefarm at x: __1__ , y: __2__

--- a/script-locale/en.cfg
+++ b/script-locale/en.cfg
@@ -5,3 +5,4 @@ notActive=not active
 toggleButtonCaption=toggle
 usedArea=used Area:
 okButtonCaption=ok
+robot_buildingFail=Robot could not place a treefarm at x: __1__ , y: __2__

--- a/script-locale/ru.cfg
+++ b/script-locale/ru.cfg
@@ -5,3 +5,4 @@ notActive=не работает
 toggleButtonCaption=Переключить
 usedArea=Область покрытия:
 okButtonCaption=ОК
+robot_buildingFail=Robot could not place a treefarm at x: __1__ , y: __2__

--- a/script-locale/sv.cfg
+++ b/script-locale/sv.cfg
@@ -5,3 +5,4 @@ notActive=inte aktivt
 toggleButtonCaption=växla
 usedArea=Använd Yta:
 okButtonCaption=ok
+robot_buildingFail=Robot could not place a treefarm at x: __1__ , y: __2__

--- a/script-locale/uk.cfg
+++ b/script-locale/uk.cfg
@@ -5,3 +5,4 @@ notActive=не працює
 toggleButtonCaption=Перемкнути
 usedArea=Зона покриття:
 okButtonCaption=ОК
+robot_buildingFail=Robot could not place a treefarm at x: __1__ , y: __2__


### PR DESCRIPTION
…invalid location.

Also show that same message to all players on the robot's force if a robot fails to place the farm

for #37 
