### PR TITLE
add homepage field in info.json

### DIFF
--- a/info.json
+++ b/info.json
@@ -5,5 +5,6 @@
   "title": "Treefarm-Lite",
   "author": "drs, Blu3wolf, Treefarm Team",
   "dependencies": ["base >= 0.13.0"],
+  "homepage": "https://github.com/Blu3wolf/Treefarm-Lite",
   "description": "This mod enables you to cultivate trees and/or other plants.\n\nhttps://github.com/Blu3wolf/Treefarm-Lite\n\nPublished under the GPLv3"
 }


### PR DESCRIPTION
Adds the github repo as the homepage in the mod metadata
