### PR TITLE
Fixes for factorio 0.14.20+

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,10 +1,10 @@
 {
   "name": "Treefarm-Lite",
-  "version": "0.5.2",
-  "factorio_version": "0.13",
+  "version": "0.5.3",
+  "factorio_version": "0.14",
   "title": "Treefarm-Lite",
   "author": "drs, Blu3wolf, Treefarm Team",
-  "dependencies": ["base >= 0.13.10"],
+  "dependencies": ["base >= 0.14.1"],
   "homepage": "https://github.com/Blu3wolf/Treefarm-Lite",
   "description": "This mod enables you to cultivate trees and/or other plants.\n\nhttps://github.com/Blu3wolf/Treefarm-Lite\n\nPublished under the GPLv3"
 }

--- a/prototypes/prototypes.lua
+++ b/prototypes/prototypes.lua
@@ -93,7 +93,7 @@ data:extend
     crafting_categories = {"treefarm-mod-dummy"},
     minable = {mining_time = 1,result = "tf-field"},
     collision_box = {{-0.5,-0.5},{0.5,0.5}},
-    selection_box = {{-0.5,-0.5},{0.5,0.5}}      
+    selection_box = {{-0.5,-0.5},{0.5,0.5}} ,     
     result_inventory_size = 4,
     energy_usage = "180kW",
     crafting_speed = 1,

--- a/prototypes/prototypes.lua
+++ b/prototypes/prototypes.lua
@@ -93,7 +93,7 @@ data:extend
     crafting_categories = {"treefarm-mod-dummy"},
     minable = {mining_time = 1,result = "tf-field"},
     collision_box = {{-0.5,-0.5},{0.5,0.5}},
-    selection_box = {{0.75,-0.50},{9.0,7.50}},
+    selection_box = {{-0.5,-0.5},{0.5,0.5}}      
     result_inventory_size = 4,
     energy_usage = "180kW",
     crafting_speed = 1,


### PR DESCRIPTION
Fixed by reducing the selection box size of MK1 farm and updating version info.